### PR TITLE
clear up explicit undefined error

### DIFF
--- a/src/angular-resource-tastypie.js
+++ b/src/angular-resource-tastypie.js
@@ -6,6 +6,9 @@
 angular.module('ngResourceTastypie',['ngResource'])
 
 .config(function($resourceProvider){
+    if($resourceProvider.defaults == undefined){
+        $resourceProvider.defaults = {};
+    }
     $resourceProvider.defaults.stripTrailingSlashes = false;
 })
 


### PR DESCRIPTION
Cleans up the following error:

TypeError: Cannot set property 'stripTrailingSlashes' of undefined 
