### PR TITLE
Corrected self.resource.working always being set to false

### DIFF
--- a/src/angular-resource-tastypie.js
+++ b/src/angular-resource-tastypie.js
@@ -154,7 +154,7 @@ angular.module('ngResourceTastypie', ['ngResource'])
             var promise = $resource(end_url).get().$promise.then(
                 function(result){
                     setPage(self, result);
-                    self.resource.working = false;
+                    // self.resource.working = false;
                     return self;
                 },
                 function(error){
@@ -188,7 +188,7 @@ angular.module('ngResourceTastypie', ['ngResource'])
                         changePage(self, (index - 1), true);
                     else{
                         setPage(self, result);
-                        self.resource.working = false;
+                        // self.resource.working = false;
                         return self;
                     }
                 },
@@ -291,7 +291,7 @@ angular.module('ngResourceTastypie', ['ngResource'])
             self.resource.working = true;
             var promise = fields.$get_uri().then(
                 function(result){
-                    self.resource.working = false;
+                    // self.resource.working = false;
                     return result;
                 },
                 function(error){
@@ -312,7 +312,7 @@ angular.module('ngResourceTastypie', ['ngResource'])
             self.resource.working = true;
             var promise = ws.then(
                 function(result){
-                    self.resource.working = false;
+                    // self.resource.working = false;
                     if (typeof(self.resource.page.refresh) == typeof(Function))
                         self.resource.page.refresh();
                     return result;
@@ -339,7 +339,7 @@ angular.module('ngResourceTastypie', ['ngResource'])
             self.resource.working = true;
             var promise = fields.$patch().then(
                 function(result){
-                    self.resource.working = false;
+                    // self.resource.working = false;
                     if (typeof(self.resource.page.refresh) == typeof(Function))
                         self.resource.page.refresh();
                     return result;
@@ -366,7 +366,7 @@ angular.module('ngResourceTastypie', ['ngResource'])
             self.resource.working = true;
             var promise = fields.$remove().then(
                 function(result){
-                    self.resource.working = false;
+                    // self.resource.working = false;
                     angular.forEach(fields, function(value, key){delete fields[key]});
                     if (typeof(self.resource.page.refresh) == typeof(Function))
                             self.resource.page.refresh();
@@ -401,7 +401,7 @@ angular.module('ngResourceTastypie', ['ngResource'])
             self.resource.working = true;
             var promise = this.$get(filter).then(
                 function(result){
-                    self.resource.working = false;
+                    // self.resource.working = false;
                     self.resource.page = new $tastypiePaginator(self.resource, filter, result);                    
                     return self.resource.page;
                 },


### PR DESCRIPTION
The api health checks were not working. I just commented out the `self.resource.working = false;` on the success callbacks, I retained those lines in the error/failure callbacks.
